### PR TITLE
Fix Artist Page Popular-Grid

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -65,3 +65,14 @@
     [var3] minmax(120px, var(--col4, 2fr))
     [last] calc(120px + var(--spicetify-playlist-labels-container-width) + 12px) !important;
 }
+
+/* Fix Artist Page Popular-Grid */
+.artist-artistOverview-popularTracks{
+    grid-column:span 4;
+}
+.artist-artistOverview-sideBlock{
+    width: 100%;
+}
+.artist-artistOverview-artistSides{
+    grid-column:span 2;
+}


### PR DESCRIPTION
Make the artist page popular tracks grid to take up more available space.

<h2>Before</h2>

![Screenshot 2024-04-26 023559](https://github.com/duffey/spicetify-playlist-labels/assets/42642682/cef24607-4111-488e-9f4b-e4fa3c678e90)

<h2>After</h2>

![Screenshot 2024-04-26 023505](https://github.com/duffey/spicetify-playlist-labels/assets/42642682/c9c40b48-df12-47e2-843f-037bfa6245a7)
